### PR TITLE
added default project_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Trajectories --> discrete trajectories --> statistics
 
 `python pipeline.py  /cbio/jclab/projects/fah/fah-data/munged-with-time/no-solvent/11400/run0-clone0.h5`
 
+Default `project_name` is 'abl', otherwise add project name in second argument:
+
+`python pipeline.py  /cbio/jclab/projects/fah/fah-data/munged-with-time/no-solvent/11400/run0-clone0.h5 'abl'`
+
 ## Details
 1. **Inputs**:
    - List of filenames of munged hdf5 trajectories

--- a/pipeline.py
+++ b/pipeline.py
@@ -172,7 +172,10 @@ def write_pdbs_of_clusters(source, msm, project_name, n_samples=10, max_states=1
 if __name__ == '__main__':
     import sys
     path_to_trajs = sys.argv[1]
-    project_name = sys.argv[2]
+    if len(sys.argv) > 2:
+        project_name = sys.argv[2]
+    else:
+        project_name = 'abl'
 
     def get_filenames(path_to_trajs):
         from glob import glob


### PR DESCRIPTION
This PR prevents an error if you do not include a second argument when running `pipeline.py`, following the old syntax. Default project name is 'abl'. Not necessarily ideal, @maxentile discussed using argparse for this, but here is a quick fix.
