### PR TITLE
Read timestep instead of hard-coding it

### DIFF
--- a/msmpipeline/msmpipeline.py
+++ b/msmpipeline/msmpipeline.py
@@ -53,7 +53,7 @@ def run_pipeline(fnames,
     '''
     ## PARAMETERIZE MSM
     # get first traj + topology
-    traj = md.load_frame(fnames[:2],0)
+    traj = md.load(fnames[0])
     top = traj.top
     
     # get timestep-- stored in units of picoseconds, converted to units of nanoseconds

--- a/msmpipeline/msmpipeline.py
+++ b/msmpipeline/msmpipeline.py
@@ -53,7 +53,7 @@ def run_pipeline(fnames,
     '''
     ## PARAMETERIZE MSM
     # get first traj + topology
-    traj = md.load_frame(fnames[0],0)
+    traj = md.load_frame(fnames[:2],0)
     top = traj.top
     
     # get timestep-- stored in units of picoseconds, converted to units of nanoseconds


### PR DESCRIPTION
Added a line that reads `traj.timestep` to set the timestep assumed in the implied timescales plots and `metastability_threshold`.
