### PR TITLE
Change command-line options and add feature specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   # Create a pyemma cache: see https://github.com/markovmodel/PyEMMA/issues/882#issuecomment-235948398
   - python -c "import pyemma ; pyemma.config.save()"
   # Run the test
-  - msm-pipeline "alanine_*.h5" "alanine" 50
+  - msm-pipeline --trajectories "alanine_*.h5" --name "alanine" --nclusters 50 --features backbone-dihedrals
 
 env:
   matrix:

--- a/msmpipeline/contact_features.py
+++ b/msmpipeline/contact_features.py
@@ -1,11 +1,37 @@
+from multiprocessing import Pool
+from functools import partial
 import mdtraj as md
 import numpy as np
+
+def get_distances(fname, scheme, stride):
+    '''
+    Function callable by a multiprocessing Pool
+    
+    Parameters
+    ----------
+    fname : string
+        filename of trajectory
+    scheme : string
+        'ca' or 'closest' or 'closest-heavy'
+    stride : int
+        thinning factor: only look at every `stride`th frame
+        
+    Returns
+    -------
+    pairwise_distances : numpy array
+    
+    residue_pairs : list of tuples
+    '''
+    traj = md.load(fname, stride = stride)
+    pairwise_distances,residue_pairs = md.compute_contacts(traj, scheme = scheme)
+    return pairwise_distances, residue_pairs
 
 def find_respairs_that_changed(fnames,
                                scheme = 'ca',    # or 'closest' or 'closest-heavy'
                                threshold = 0.4,
                                stride = 100,
-                               max_respairs = 1000):
+                               max_respairs = 1000,
+                               num_threads = 12):
     '''
     Finds all the residue pairs that crossed `threshold` at least once in a strided subset of 
     trajectory data. If that number of features is still too high, just take the top `max_respairs`
@@ -28,18 +54,21 @@ def find_respairs_that_changed(fnames,
         
     max_respairs : int
         maximum number of features to return
+        
+    num_threads : int
+        number of threads to use 
     
     Returns
     -------
     respairs_that_changed : list of tuples
         each element of the list is a length-2 tuple
     '''
-    distances = []
-    for fname in fnames:
-        traj = md.load(fname, stride = stride)
-        pairwise_distances,residue_pairs = md.compute_contacts(traj, scheme = scheme)
-        distances.append(pairwise_distances)
-    distances = np.vstack(distances)
+    # parallelize over fnames
+    pool = Pool(num_threads)
+    get_distances_ = partial(get_distances, scheme=scheme, stride=stride)
+    distances = pool.map(get_distances_, fnames)
+    residue_pairs = distances[0][1]
+    distances = np.vstack([d[0] for d in distances])
 
     # identify contacts that change by counting how many times the distances were
     # greater than and less than the threshold

--- a/msmpipeline/msmpipeline.py
+++ b/msmpipeline/msmpipeline.py
@@ -151,7 +151,7 @@ def run_pipeline(fnames,
     eigs = tica.eigenvalues
     plt.figure()
     plt.plot(np.cumsum(eigs ** 2))
-    plt.vlines(dim, 0, np.cumsum(eigs ** 2)[dim])
+    plt.vlines(dim, 0, np.sum((eigs ** 2)[:dim]))
     plt.xlabel('# tICA eigenvalues')
     plt.ylabel('Cumulative sum of tICA eigenvalues squared')
     plt.title('Cumulative "kinetic variance" explained')

--- a/msmpipeline/msmpipeline.py
+++ b/msmpipeline/msmpipeline.py
@@ -18,6 +18,7 @@ def run_pipeline(fnames,
                  n_structures_per_macrostate = 10,
                  in_memory = True,
                  max_n_macrostates = 20,
+                 feature_selection = 'backbone-dihedrals',
                  ):
     '''
     Generates an MSM using sensible defaults. Computes angle-based features, turns
@@ -51,21 +52,27 @@ def run_pipeline(fnames,
 
     in_memory : bool
       whether to featurize in one go or to iterate over chunks
-      
+
     max_n_macrostates : int
       override estimated n_macrostates if it exceeds max_n_macrostates
+
+    feature_selection : str, optional, default = 'backbone-dihedrals'
+      choice of features: ['backbone-dihedrals']
     '''
     ## PARAMETERIZE MSM
     # get first traj + topology
     traj = md.load(fnames[0])
     top = traj.top
-    
+
     # get timestep-- stored in units of picoseconds, converted to units of nanoseconds
     timestep = traj.timestep / 1000
-    
+
     # create featurizer
     feat = pyemma.coordinates.featurizer(top)
-    feat.add_backbone_torsions(cossin = True)
+    if feature_selection == 'backbone-dihedrals':
+        feat.add_backbone_torsions(cossin = True)
+    else:
+        raise Exception("Feature choice '%s' unknown." % feature_selection)
     n_features = len(feat.describe())
 
     dim = min(n_features, max_tics)
@@ -115,12 +122,12 @@ def run_pipeline(fnames,
     elif n_macrostates > msm.nstates:
         print("Huh? Somehow the MSM had more timescales than states.")
         n_macrostates = msm.nstates
-   
+
     # ignore this estimate if it exceeds max_n_macrostates
     if n_macrostates > max_n_macrostates:
         print("Estimated n_macrostates exceeds max_n_macrostates, reverting to {0}".format(max_n_macrostates))
         n_macrostates = max_n_macrostates
-        
+
     # coarse-grain
     hmm = pyemma.msm.estimate_hidden_markov_model(dtrajs, n_macrostates, msm_lag, maxit=1)
 
@@ -129,7 +136,7 @@ def run_pipeline(fnames,
 
     # write PDBs
     pyemma.coordinates.save_trajs(source, indices, prefix=project_name, fmt = 'pdb')
-    
+
     # write macrostate free energies
     f_i = -np.log(hmm.stationary_distribution)
     f_i -= f_i.min()
@@ -165,7 +172,7 @@ def run_pipeline(fnames,
 
     for i, lags in enumerate(lag_sets):
         its = pyemma.msm.its(dtrajs, lags, nits=20, errors='bayes')
-        plt.figure()        
+        plt.figure()
         pyemma.plots.plot_implied_timescales(its, units='ns', dt=timestep)
         plt.savefig('{0}_its_{1}.png'.format(project_name, i), dpi=300)
         plt.close()
@@ -182,26 +189,30 @@ def run_pipeline(fnames,
     plt.close()
 
 def main():
-    import sys
-    path_to_trajs = sys.argv[1]
-    project_name = 'abl'
-    n_clusters = 1000
-    if len(sys.argv) > 2:
-        project_name = sys.argv[2]
-    if len(sys.argv) > 3:
-        n_clusters = int(sys.argv[3])
+    from optparse import OptionParser
+    parser = OptionParser()
+    parser.add_option("-t", "--trajectories", dest="path_to_trajs", type="string",
+                      help="path to trajectories (must be quoted if wildcards are used)")
+    parser.add_option("-n", "--name", dest="project_name", type="string",
+                      help="don't print status messages to stdout", default="abl")
+    parser.add_option("-c", "--nclusters", dest="n_clusters", type="int",
+                      help="number of clusters", default=1000)
+    parser.add_option("-f", "--features", dest="feature_selection", type="string",
+                      help="choice of features: ['backbone-dihedrals']", default="backbone-dihedrals")
+
+    (options, args) = parser.parse_args()
 
     def get_filenames(path_to_trajs):
         from glob import glob
         filenames = glob(path_to_trajs)
         return filenames
 
-    print(path_to_trajs)
-    fnames = get_filenames(path_to_trajs)
+    print(options.path_to_trajs)
+    fnames = get_filenames(options.path_to_trajs)
     print(fnames)
 
     print('Running pipeline')
-    run_pipeline(fnames, project_name = project_name, n_clusters = n_clusters)
+    run_pipeline(fnames, project_name = options.project_name, n_clusters = options.n_clusters, feature_selection = options.feature_selection)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This changes to use `optparse` for command-line option parsing, and adds a `--features featname` specification as in #29.

An example command-line is now:

```
msm-pipeline --trajectories "alanine_*.h5" --name "alanine" --nclusters 50 --features backbone-dihedrals
```

Help is now:

```
[LSKI1497:choderalab/msm-pipeline/msm-pipeline.choderalab] choderaj% msm-pipeline --help
Usage: msm-pipeline [options]

Options:
  -h, --help            show this help message and exit
  -t PATH_TO_TRAJS, --trajectories=PATH_TO_TRAJS
                        path to trajectories (must be quoted if wildcards are
                        used)
  -n PROJECT_NAME, --name=PROJECT_NAME
                        don't print status messages to stdout
  -c N_CLUSTERS, --nclusters=N_CLUSTERS
                        number of clusters
  -f FEATURE_SELECTION, --features=FEATURE_SELECTION
                        choice of features: ['backbone-dihedrals']
```

Hopefully 
